### PR TITLE
add cors to allow all request

### DIFF
--- a/lib/beebee/router.ex
+++ b/lib/beebee/router.ex
@@ -4,6 +4,7 @@ defmodule BeeBee.Router do
   alias BeeBee.ShortenedURL
 
   plug Plug.Logger
+  plug CORSPlug, origins: ["*"]
   plug Plug.Parsers, parsers: [:json], json_decoder: Poison
   plug :match
   plug :dispatch

--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,7 @@ defmodule BeeBee.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      {:cors_plug,    "~> 1.1"},
       {:cowboy,       "~> 1.0"},
       {:plug,         "~> 1.1"},
       {:exredis,      ">= 0.2.4"},


### PR DESCRIPTION
The cors plugin was not added to the router, so Api errors were occuring due to unconfigured policies.