### PR TITLE
Make code blocks look nicer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ BeeBee exposes two API endpoints, `POST /_add` and `GET /_stats`.
 
 **Accepts:**
 
-```json
+```js
 {
   "url": "https://github.com", // URL to be shortened
   "short_tag": "github" // OPTIONAL short tag
@@ -33,7 +33,7 @@ If a short tag is omitted, one will be randomly generated for you.
 
 **Returns:**
 
-```json
+```js
 {
   "short_tag": "github" // Short tag now mapped to the provided URL
 }
@@ -43,7 +43,7 @@ If a short tag is omitted, one will be randomly generated for you.
 
 **Returns:**
 
-```json
+```js
 [
   {
     "short_tag": "github",


### PR DESCRIPTION
This would remove the red highlight from the comments in the examples in README.md in the GitHub view.

## Before

![Screen Shot 2020-12-12 at 11 14 15 PM](https://user-images.githubusercontent.com/5182991/102002985-f4546300-3ccf-11eb-9eb9-81c8900dd4ab.png)

## After

![Screen Shot 2020-12-12 at 11 14 36 PM](https://user-images.githubusercontent.com/5182991/102002988-f7e7ea00-3ccf-11eb-8aff-85c4ced46e1e.png)
